### PR TITLE
Make form validate on mount configurable

### DIFF
--- a/examples/enroll.tsx
+++ b/examples/enroll.tsx
@@ -139,6 +139,7 @@ export interface EnrollData {
   dateAt?: Date,
   tz: string,
   firstName: string,
+  firstNameWithAutoComplete: string,
   lastName: string,
   pin: string,
   phone: string,
@@ -217,6 +218,7 @@ const Enroll = ({ onSubmit, data, isDisabled, isLarge }: EnrollProps): JSX.Eleme
     examAt: null,
     tz: 'US/Mountain',
     firstName: 'John',
+    firstNameWithAutoComplete: '',
     lastName: 'Doe',
     pin: '123',
     phone: '',
@@ -279,6 +281,7 @@ const Enroll = ({ onSubmit, data, isDisabled, isLarge }: EnrollProps): JSX.Eleme
       <Form
         form={form}
         validate={validate}
+        validateOnMount={false}
         onSubmit={onSubmit}
         onChange={onChange}
       >
@@ -337,6 +340,16 @@ const Enroll = ({ onSubmit, data, isDisabled, isLarge }: EnrollProps): JSX.Eleme
               large={isLarge}
               disabled={isDisabled}
               onChange={onFieldChange.bind(this, 'firstName')}
+            />
+            <TextInput
+              className="mb-0 pb-0"
+              label="First Name (With Autocomplete)"
+              name="firstNameWithAutoComplete"
+              autoComplete="given-name"
+              pattern={REGEX_NAME}
+              patternError="Please enter a valid first name."
+              onChange={onFieldChange.bind(this, 'firstNameWithAutoComplete')}
+              required
             />
             <TextInput
               label="Last Name"

--- a/examples/enroll.tsx
+++ b/examples/enroll.tsx
@@ -328,6 +328,7 @@ const Enroll = ({ onSubmit, data, isDisabled, isLarge }: EnrollProps): JSX.Eleme
               name="dateAt"
               format="MM/DD"
               fill
+              autoComplete="bday"
               large={isLarge}
               disabled={isDisabled}
               onChange={onFieldChange.bind(this, 'dateAt')}

--- a/src/components/date.tsx
+++ b/src/components/date.tsx
@@ -148,6 +148,7 @@ class DateInput extends Markup<DateInputProps & { formik?: FormikContextType<For
           style: this.props.style,
           large: this.props.large,
           intent: meta.error && meta.touched ? 'danger' : 'none',
+          autoComplete: this.props.autoComplete ? this.props.autoComplete : 'off'
         }}
         value={meta.value}
         onChange={(value: Date) => {

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -67,6 +67,7 @@ interface FormProps<Values extends FormikValues, S extends any = never> {
   form: FormInstance<Values, S>,
   validate?: (values: Values) => void | FormErrors | Promise<FormErrors>;
   validateOnChange?: boolean;
+  validateOnMount?: boolean;
   children?: ((props: FormikProps<Values>) => JSX.Element) | JSX.Element | JSX.Element[],
   onSubmit?: (data: any) => void,
   onChange?: (data: any, isValid: boolean) => void,
@@ -78,6 +79,7 @@ const Form = <Values extends FormikValues, S extends any = never>({
   form: instance,
   validate,
   validateOnChange,
+  validateOnMount = true,
   children,
   onSubmit,
   onChange,
@@ -95,7 +97,7 @@ const Form = <Values extends FormikValues, S extends any = never>({
       initialValues={instance.initialData}
       validate={validate}
       validateOnChange={validateOnChange}
-      validateOnMount={true}
+      validateOnMount={validateOnMount}
       onSubmit={(data) => instance.onSubmit(data, onSubmit)}
     >
       {(props) => {


### PR DESCRIPTION
Beyond making the `validateOnMount` prop changeable on the `<Form/>` element, this PR also passes the `autoComplete` prop to the underlying BP `<DateInput/>` properly so that it actually works.

 Both of these changes are necessary to improve our a11y score with Aetna.