### PR TITLE
Resolve DateInput TypeError

### DIFF
--- a/src/components/date.tsx
+++ b/src/components/date.tsx
@@ -79,10 +79,10 @@ class DateInput extends Markup<DateInputProps & { formik?: FormikContextType<For
     return _date.format(this.props.format || DEFAULT_FORMAT);
   }
 
-  private parseDate(value: string): Date | null {
+  private parseDate(value: string): Date | false {
     const date = moment(value, this.props.format || DEFAULT_FORMAT);
     if (!date.isValid()) {
-      return null;
+      return false;
     }
     return date.toDate();
   }


### PR DESCRIPTION
**Previous Behavior**
- Getting `Cannot read properties of null (reading 'valueOf')` when entering bunch of random numbers in `<DateInput />` ([Sentry error](https://sentry.io/organizations/caresignal/issues/3093965425/?project=5434087&query=is%3Aunresolved))

https://user-images.githubusercontent.com/101577626/166961970-3ace9268-d0f3-4743-a0d0-5f6e73261841.mov

**Current Behavior**
- No longer getting TypeError

https://user-images.githubusercontent.com/101577626/166962044-7e9f49f2-bb34-4043-9b3e-39cd283bec0b.mov

